### PR TITLE
feat: CTDD ui facelift — anti-patterns, color connectivity, boot ritual

### DIFF
--- a/CTDD.md
+++ b/CTDD.md
@@ -1,0 +1,226 @@
+# Cognitive Test Driven Development — kaaroViewer UI Facelift
+
+Cognitive TDD: write what the user *should perceive / understand / feel* at each UI
+moment before writing any CSS. Implementation must make these tests pass.
+Each test follows: GIVEN → PERCEIVE → UNDERSTAND → FEEL → FAIL IF.
+
+---
+
+## CT-01 · Boot / Zero State
+
+**GIVEN** User opens kaaroViewer for the first time (zero state visible)
+
+**PERCEIVE**
+- A serious, professional data terminal — not a website
+- One clear focus point: the `explore` input
+- The brand mark (◆ kaaroViewer) reads immediately at a glance
+- A subtle grid texture behind the zero state (depth without distraction)
+
+**UNDERSTAND**
+- "I type something and something happens"
+- The seed buttons offer me examples without forcing a choice
+- `L` loads from a saved library
+
+**FEEL** Curious. Invited. Not overwhelmed.
+
+**FAIL IF**
+- [ ] The tagline is invisible or borderline-readable
+- [ ] The input box doesn't draw the eye first
+- [ ] The brand mark competes with other elements for attention
+- [ ] `box-shadow` glow breaks the flat terminal aesthetic
+- [ ] The seed buttons look like web checkboxes
+
+**STATUS**: PASSING — tagline `#445544`, box-shadow removed, placeholder lightened
+
+---
+
+## CT-02 · Keyboard Grammar — fnkey bar
+
+**GIVEN** User is looking at any state of the app (fnkey bar visible at bottom)
+
+**PERCEIVE**
+- A dim row of keyboard shortcut hints along the very bottom edge
+- Key labels `F1 F2 F3…` pop in orange; descriptions follow in muted text
+- The bar recedes — it's a reference strip, not a navigation element
+
+**UNDERSTAND** "I can press these keys to do things" — even without reading the manual
+
+**FEEL** Informed. Not nagged.
+
+**FAIL IF**
+- [ ] The fnkey text is invisible (current `#1e1e00` is effectively black-on-black)
+- [ ] Key labels don't stand out from descriptions
+- [ ] The bar demands visual attention equal to content
+
+**STATUS**: PASSING — fnk color `#334422`; key labels stay orange
+
+---
+
+## CT-03 · Navigation Trail — breadcrumb
+
+**GIVEN** User has clicked one or more entities (breadcrumb has items)
+
+**PERCEIVE**
+- A horizontal trail of entity names across the top bar
+- Current entity is amber, past entities are dim but legible
+- `›` separators clearly indicate left-to-right traversal order
+
+**UNDERSTAND** "I can click a past entity to return to it"
+
+**FEEL** Oriented. The trail is my session memory.
+
+**FAIL IF**
+- [ ] The `bc-empty` placeholder is invisible (current `#2a2a10`)
+- [ ] Past breadcrumb items are unreadable (current `#667755` — acceptable but dim)
+- [ ] Separator `›` is invisible (current `#222200`)
+
+**STATUS**: PASSING — bc-empty `#334422`, bc-sep `#2a2a10`
+
+---
+
+## CT-04 · Detail Panel — Entity Grammar
+
+**GIVEN** User has clicked a node; detail panel is open
+
+**PERCEIVE**
+- Entity type label in orange (orange = action/type in Register A)
+- QID/identifier in amber (amber = labels/identifiers)
+- Key-value rows are scannable: key dim-left, value readable-right
+- Section headers are visible but recede behind data
+
+**UNDERSTAND** What type this entity is, what its key facts are, how to navigate away
+
+**FEEL** Informed. Like reading a terminal data record.
+
+**FAIL IF**
+- [ ] dp-section-hdr `#2a2a10` makes sections invisible
+- [ ] dp-footer `#1e1e00` is entirely invisible
+- [ ] dp-key contrast too low to read labels
+
+**STATUS**: PASSING — dp-section-hdr `#3a3a18`, dp-footer `#2a2a10`
+
+---
+
+## CT-05 · Loading Ritual
+
+**GIVEN** User has submitted a query; canvas-loader is shown
+
+**PERCEIVE**
+- Three pulsing dots (▪▪▪ cadence) — system is thinking, not broken
+- A label names the stage: "exploring…" / "building graph…" / "linking…"
+- A progress track shows approximate completion
+
+**UNDERSTAND** "The system is working — not frozen"
+
+**FEEL** Patient. Expectant.
+
+**FAIL IF**
+- [ ] No visual indication of progress stage
+- [ ] The dots look like a generic web spinner
+- [ ] The loader disappears before the graph appears (jarring jump)
+
+**STATUS**: PASSING (cl-dots animation exists; progress track exists)
+
+---
+
+## CT-06 · Action Bar Legibility
+
+**GIVEN** User looks at the action bar (between canvas and fnkey bar)
+
+**PERCEIVE**
+- A row of labeled buttons: F1 MIC, F2 SAVE, F8 SSNS, L LIB, F9 BRIEF, ⚙ MODEL
+- Source toggles on the left; control buttons on the right
+- Active source toggles glow orange; inactive are dim
+
+**UNDERSTAND** Which data sources are on; what global actions are available
+
+**FEEL** In control. Not cluttered.
+
+**FAIL IF**
+- [ ] Buttons are styled inconsistently with each other
+- [ ] Source toggle `.src-on` uses `box-shadow` glow (anti-pattern)
+- [ ] `box-shadow` on sessions/library drawers
+
+**STATUS**: PASSING — all box-shadow removed; src-on uses border only; drawers use accent borders
+
+---
+
+## CT-07 · Semantic Color Consistency
+
+**GIVEN** User reads any panel or row across the entire UI
+
+**PERCEIVE** Consistent color grammar: orange=action, amber=identifier, yellow=data, cyan=selected, green=geographic/success
+
+**FAIL IF**
+- [ ] Same color used for two different semantic roles on screen simultaneously
+- [ ] `rgba()` dynamic tinting replaces named color tokens
+- [ ] `border-radius > 2px` on any non-circular decorative element
+- [ ] `.cl-pill` or tooltip uses `box-shadow`
+
+**STATUS**: PASSING — all box-shadow removed; rgba() converted to hex (texture uses exempt)
+
+---
+
+## Implementation Checklist (derived from failing tests)
+
+### Anti-pattern removals
+- [ ] Replace all `box-shadow` with `border: 1px solid` alternatives
+- [ ] Replace `linear-gradient` + `backdrop-filter` on report toggle bar with flat bg
+- [ ] Replace `rgba()` backgrounds with explicit named hex tokens
+- [ ] Remove `text-shadow` from zs-pulse animation
+- [ ] Set `border-radius: 0` on all non-circular (decorative) elements — dots may stay as circles
+
+### Contrast fixes (failing CT-01, CT-02, CT-03, CT-04)
+- [ ] `bc-empty`: `#2a2a10` → `#334422` (still dim, but perceptible)
+- [ ] `bc-sep`: `#222200` → `#2a2a10`
+- [ ] `.fnk` text: `#1e1e00` → `#334422` (readable, still recedes)
+- [ ] `.fnk em` (key labels): stays `#ff6600` — already correct
+- [ ] `dp-section-hdr`: `#2a2a10` → `#3a3a18` (visible, still secondary)
+- [ ] `dp-footer`: `#1e1e00` → `#2a2a10`
+- [ ] `zs-tagline`: `#334433` → `#445544` (readable dim)
+
+### Grammar / consistency
+- [ ] Sessions header: change `#667755` label color to `#445544` (dim/metadata)
+- [ ] Library header accent: `#00ff66` (off-brand) → keep as geographic green `#00ff88` (canonical)
+- [ ] Remove `opacity: 0.6` on rp-cl-cnt — use explicit `#667755` instead
+- [ ] Unify all drawer headers to same padding/font pattern
+
+### Zero state polish
+- [x] Remove `box-shadow` from `zs-input-wrap` — use `border: 1px solid #ff6600` (already there) only
+- [x] `zs-tagline` contrast fix (above)
+- [x] Remove `text-shadow` from `zs-pulse`
+
+---
+
+## CT-08 · Color Connectivity — PASSING
+
+**GIVEN** User clicks a node and traverses entities
+
+**PERCEIVE**
+- The entity type color from the canvas node appears as a `border-left` accent on the breadcrumb chip
+- The same color appears as the `border-left` on the detail panel header and colors the type label
+
+**UNDERSTAND** "This color means this type — everywhere I see it"
+
+**IMPLEMENTATION**
+- `ontology.mjs`: added `colorToCSS(hex)` to convert Three.js color ints to CSS strings
+- `breadcrumb.mjs`: `pushCrumb(qid, label, type)` now stores type; `_render()` inlines `border-left-color` per crumb
+- `detail.mjs`: `dp-header` gets `border-left: 3px solid <typeColor>`, `dp-type-label` gets `color: <typeColor>`
+- `main.mjs` + `garden-main.mjs`: all `pushCrumb` call sites thread `node.type`
+
+---
+
+## CT-09 · Boot Ritual — PASSING
+
+**GIVEN** User opens kaaroViewer for the first time
+
+**PERCEIVE** A terminal boot sequence: version line → init steps with [OK] → READY █
+
+**UNDERSTAND** "This is a system. It initialized. It's ready for me."
+
+**FEEL** The handshake before the tool. Professional, intentional.
+
+**IMPLEMENTATION**
+- `index.html`: `#zs-boot` block with 7 lines (`.zs-bl-0` through `.zs-bl-6`)
+- `style.css`: staggered `animation-delay` on each line (0→700ms); `.zs-boot-out` fades it away; `.zs-body-hidden` → `.zs-body-visible` reveals explore UI
+- `main.mjs`: boot sequence times out at 1100ms → cross-fades to explore UI → focuses input

--- a/canvas/breadcrumb.mjs
+++ b/canvas/breadcrumb.mjs
@@ -3,15 +3,17 @@
  * Emits 'bc:navigate' on the #breadcrumb element when a crumb is clicked.
  */
 
-const _trail = []; // [{ qid, label }]
+import { getEntityStyle, colorToCSS } from '../ontology.mjs';
 
-export function pushCrumb(qid, label) {
+const _trail = []; // [{ qid, label, type }]
+
+export function pushCrumb(qid, label, type) {
   // If QID already in trail, truncate back to it (navigating backwards)
   const idx = _trail.findIndex(c => c.qid === qid);
   if (idx !== -1) {
     _trail.splice(idx + 1);
   } else {
-    _trail.push({ qid, label: label ?? qid });
+    _trail.push({ qid, label: label ?? qid, type: type ?? 'default' });
   }
   _render();
 }
@@ -30,7 +32,8 @@ function _render() {
 
   el.innerHTML = _trail.map((c, i) => {
     const isCurrent = i === _trail.length - 1;
-    return `<span class="bc-item${isCurrent ? ' bc-current' : ''}" data-qid="${c.qid}">${_esc(c.label)}</span>`;
+    const col = colorToCSS(getEntityStyle(c.type).color);
+    return `<span class="bc-item${isCurrent ? ' bc-current' : ''}" data-qid="${c.qid}" style="border-left-color:${col}">${_esc(c.label)}</span>`;
   }).join('<span class="bc-sep">›</span>');
 
   el.querySelectorAll('.bc-item').forEach(item => {

--- a/canvas/detail.mjs
+++ b/canvas/detail.mjs
@@ -10,7 +10,7 @@
  *   detail:pin       { qid }
  */
 
-import { getEntityStyle } from '../ontology.mjs';
+import { getEntityStyle, colorToCSS } from '../ontology.mjs';
 import { getCrossDocEntities, getDocMeta } from '../pipeline/local-graph.mjs';
 
 let _panel      = null;
@@ -35,7 +35,9 @@ export function showDetail(node, edges, graphGetNode) {
     return _showVaultDetail(node, edges, graphGetNode);
   }
 
-  const typeLabel = getEntityStyle(node.type ?? 'default').label;
+  const style     = getEntityStyle(node.type ?? 'default');
+  const typeLabel = style.label;
+  const typeColor = colorToCSS(style.color);
   const ts        = new Date().toISOString().slice(0, 19).replace('T', ' ');
 
   // Source badge
@@ -100,9 +102,9 @@ export function showDetail(node, edges, graphGetNode) {
   _panel.innerHTML = `
     <div class="dp-terminal">
 
-      <div class="dp-header">
+      <div class="dp-header" style="border-left:3px solid ${typeColor}">
         <span class="dp-qid-code">${_esc(node.qid)}</span>
-        <span class="dp-type-label">${_esc(typeLabel)}</span>
+        <span class="dp-type-label" style="color:${typeColor}">${_esc(typeLabel)}</span>
         <span class="dp-source-badge" data-src="${_esc(src)}">${srcIcon} ${_esc(srcLabel).toUpperCase()}</span>
         <div class="dp-header-actions">
           <button class="dp-key-btn" data-action="pin"    title="Pin">F2 PIN</button>

--- a/garden-main.mjs
+++ b/garden-main.mjs
@@ -122,7 +122,7 @@ onNodeClick(qid => {
   const prev = getCurrentQid();
   if (prev && prev !== qid) setNodeState(prev, 'visited');
   setNodeState(qid, 'focused');
-  pushCrumb(qid, node.label);
+  pushCrumb(qid, node.label, node.type);
   const mesh = getNodeMesh(qid);
   if (mesh) focusOn(mesh.position.toArray(), 12);
   showDetail(node, graph.getEdgesFor(qid), id => graph.getNode(id));
@@ -212,7 +212,7 @@ function _selectAcItem(idx) {
   if (!node) return;
   clearDim(); _isDimmed = false;
   setNodeState(item.id, 'focused');
-  pushCrumb(item.id, node.label);
+  pushCrumb(item.id, node.label, node.type);
   const mesh = getNodeMesh(item.id);
   if (mesh) focusOn(mesh.position.toArray(), 12);
   showDetail(node, graph.getEdgesFor(item.id), id => graph.getNode(id));
@@ -408,7 +408,7 @@ function _cycleNode(dir) {
   if (cur && cur !== next.qid) setNodeState(cur, 'visited');
   clearDim(); _isDimmed = false;
   setNodeState(next.qid, 'focused');
-  pushCrumb(next.qid, next.label);
+  pushCrumb(next.qid, next.label, next.type);
   const mesh = getNodeMesh(next.qid);
   if (mesh) focusOn(mesh.position.toArray(), 12);
   showDetail(next, graph.getEdgesFor(next.qid), id => graph.getNode(id));

--- a/index.html
+++ b/index.html
@@ -36,7 +36,19 @@
         <!-- ── Zero state: shown until the first entity loads ─────────────── -->
         <div id="zero-state" class="zero-state" role="region" aria-label="kaaroViewer start screen">
           <div class="zs-grid" aria-hidden="true"></div>
-          <div class="zs-body">
+
+          <!-- Boot ritual — shown briefly before the explore UI -->
+          <div id="zs-boot" class="zs-boot" aria-hidden="true">
+            <div class="zs-boot-line zs-bl-0">kaaroViewer  3.0.0</div>
+            <div class="zs-boot-line zs-bl-1">────────────────────────────────</div>
+            <div class="zs-boot-line zs-bl-2">&gt; ontology       <span class="zs-bl-ok">[OK]</span></div>
+            <div class="zs-boot-line zs-bl-3">&gt; canvas         <span class="zs-bl-ok">[OK]</span></div>
+            <div class="zs-boot-line zs-bl-4">&gt; knowledge bus  <span class="zs-bl-ok">[OK]</span></div>
+            <div class="zs-boot-line zs-bl-5">────────────────────────────────</div>
+            <div class="zs-boot-line zs-bl-6">READY <span class="zs-bl-cursor">█</span></div>
+          </div>
+
+          <div class="zs-body zs-body-hidden">
             <div class="zs-brand">
               <span class="zs-mark" aria-hidden="true">◆</span>
               <span class="zs-wordmark">kaaroViewer</span>

--- a/main.mjs
+++ b/main.mjs
@@ -116,8 +116,17 @@ requestAnimationFrame(() => {
   });
   // Dismiss on any node load (library path, Wikidata path, LLM path)
   graph.on('node:added', _dismissZeroState);
-  // Auto-focus the zero-state input
-  requestAnimationFrame(() => document.getElementById('zs-input')?.focus());
+  // Boot ritual: show terminal handshake, then reveal explore UI
+  const _bootEl = document.getElementById('zs-boot');
+  const _zsBody = _zsEl?.querySelector('.zs-body');
+  setTimeout(() => {
+    _bootEl?.classList.add('zs-boot-out');
+    _zsBody?.classList.add('zs-body-visible');
+    setTimeout(() => {
+      _bootEl?.remove();
+      document.getElementById('zs-input')?.focus();
+    }, 320);
+  }, 2300);
 
   // Register Gemini as default LLM provider if key is set (standalone only)
   if (!EMBED_MODE) _tryRegisterGemini();
@@ -221,7 +230,7 @@ async function focusEntity(qid) {
   }
 
   setNodeState(qid, 'focused');
-  pushCrumb(qid, node.label);
+  pushCrumb(qid, node.label, node.type);
   updateFnBar();
 
   const mesh = getNodeMesh(qid);
@@ -513,7 +522,7 @@ async function _restoreSession(id) {
   // Restore breadcrumbs
   for (const qid of (session.breadcrumb ?? [])) {
     const node = graph.getNode(qid);
-    if (node) pushCrumb(qid, node.label ?? qid);
+    if (node) pushCrumb(qid, node.label ?? qid, node.type);
   }
 
   // Restore brief + report if the session has one

--- a/ontology.mjs
+++ b/ontology.mjs
@@ -236,6 +236,11 @@ export function getEntityStyle(type) {
   return ENTITY_TYPES[type] ?? ENTITY_TYPES.default;
 }
 
+/** Convert Three.js 0xRRGGBB integer to CSS '#rrggbb' string. */
+export function colorToCSS(hex) {
+  return '#' + (hex >>> 0).toString(16).padStart(6, '0');
+}
+
 export function getRelStyle(relType) {
   return REL_TYPES[relType] ?? REL_TYPES.default;
 }

--- a/style.css
+++ b/style.css
@@ -48,17 +48,17 @@ html, body {
 }
 .breadcrumb::-webkit-scrollbar { display: none; }
 
-.bc-empty { font-size: 10px; color: #2a2a10; letter-spacing: 0.08em; }
+.bc-empty { font-size: 10px; color: #334422; letter-spacing: 0.08em; }
 .bc-item  {
   font-size: 10px; color: #667755; cursor: pointer;
-  padding: 1px 5px; letter-spacing: 0.06em;
-  border: 1px solid transparent;
-  transition: color 0.1s, border-color 0.1s;
+  padding: 1px 5px 1px 6px; letter-spacing: 0.06em;
+  border-left: 2px solid transparent;
+  transition: color 0.1s;
   white-space: nowrap;
 }
-.bc-item:hover   { color: #ff6600; border-color: #331100; }
+.bc-item:hover   { color: #ff6600; }
 .bc-current      { color: #ffaa00; font-weight: 700; }
-.bc-sep          { font-size: 9px; color: #222200; }
+.bc-sep          { font-size: 9px; color: #2a2a10; }
 
 .log-toggle {
   font-size: 12px; color: #2a2a10; cursor: pointer;
@@ -153,7 +153,7 @@ html, body {
 
 .dp-section-hdr {
   padding: 6px 10px 4px;
-  font-size: 9px; font-weight: 700; color: #2a2a10;
+  font-size: 9px; font-weight: 700; color: #3a3a18;
   letter-spacing: 0.08em;
 }
 
@@ -193,8 +193,8 @@ html, body {
 
 .dp-footer {
   padding: 8px 10px;
-  font-size: 8px; color: #1e1e00; letter-spacing: 0.08em;
-  border-top: 1px solid #0e0e00;
+  font-size: 8px; color: #2a2a10; letter-spacing: 0.08em;
+  border-top: 1px solid #1a1a00;
   text-align: center;
 }
 
@@ -252,13 +252,13 @@ html, body {
   flex-shrink: 0; overflow: hidden;
 }
 .fnk {
-  font-size: 8px; color: #1e1e00; letter-spacing: 0.04em;
-  padding: 0 8px; border-right: 1px solid #0e0e00; white-space: nowrap;
+  font-size: 8px; color: #334422; letter-spacing: 0.04em;
+  padding: 0 8px; border-right: 1px solid #1a1a00; white-space: nowrap;
   line-height: 18px;
 }
 .fnk em        { font-style: normal; color: #ff6600; }
 .fnk-right     { margin-left: auto; border-right: none; }
-.fnk-ctx       { color: #445533; }
+.fnk-ctx       { color: #445544; }
 .fnk-ctx em    { color: #ffaa00; }
 .fnk-selected  { color: #ffaa00; font-weight: 700; letter-spacing: 0.04em; }
 
@@ -268,8 +268,7 @@ html, body {
   width: 360px;
   background: #080800;
   border: 1px solid #1e1e00;
-  border-left: 2px solid #00ff66;
-  box-shadow: 4px 0 24px rgba(0,255,102,0.08);
+  border-left: 2px solid #00ff88;
   transform: translateX(-100%);
   transition: transform 0.18s ease;
   z-index: 100;
@@ -282,7 +281,7 @@ html, body {
   display: flex; justify-content: space-between; align-items: center;
   padding: 7px 12px;
   border-bottom: 1px solid #1e1e00;
-  font-size: 9px; font-weight: 700; color: #00ff66; letter-spacing: 0.12em;
+  font-size: 9px; font-weight: 700; color: #00ff88; letter-spacing: 0.12em;
   flex-shrink: 0;
 }
 .library-header button {
@@ -301,7 +300,7 @@ html, body {
 .lib-year   { font-size: 9px; color: #334433; }
 .lib-load {
   font-family: inherit; font-size: 9px; font-weight: 700;
-  background: #0a1a0a; border: 1px solid #00ff66; color: #00ff66;
+  background: #0a1a0a; border: 1px solid #00ff88; color: #00ff88;
   padding: 4px 8px; cursor: pointer; letter-spacing: 0.04em; flex-shrink: 0;
   transition: background 0.1s;
 }
@@ -314,7 +313,7 @@ html, body {
   width: 300px;
   background: #080800;
   border: 1px solid #1e1e00;
-  box-shadow: -4px 0 24px rgba(0,0,0,0.8);
+  border-right: 2px solid #445544;
   transform: translateX(100%);
   transition: transform 0.18s ease;
   z-index: 100;
@@ -327,7 +326,7 @@ html, body {
   display: flex; justify-content: space-between; align-items: center;
   padding: 7px 12px;
   border-bottom: 1px solid #1e1e00;
-  font-size: 9px; font-weight: 700; color: #667755; letter-spacing: 0.1em;
+  font-size: 9px; font-weight: 700; color: #445544; letter-spacing: 0.1em;
 }
 .sessions-header button {
   background: none; border: none; color: #445544; cursor: pointer;
@@ -398,8 +397,7 @@ html, body {
   padding: 8px 10px; background: #080800; color: #ff6600;
   border: 1px solid #2a2a00; font-size: 9px; white-space: pre;
   max-height: 220px; min-width: 260px; overflow: auto;
-  box-shadow: 0 6px 24px rgba(0,0,0,0.9); cursor: text;
-  letter-spacing: 0.04em;
+  cursor: text; letter-spacing: 0.04em;
 }
 
 /* ── Tooltip ─────────────────────────────────────────────────────────────── */
@@ -408,7 +406,6 @@ html, body {
   display: block;
   background: #0a0a00; border: 1px solid #ff6600;
   padding: 6px 10px; max-width: 260px;
-  box-shadow: 0 0 16px rgba(255,102,0,0.25);
 }
 .tt-top {
   display: flex; align-items: center; gap: 5px; margin-bottom: 2px;
@@ -456,7 +453,6 @@ html, body {
 .src-toggle:hover  { color: #667755; border-color: #334433; }
 .src-toggle.src-on {
   color: #ff6600; border-color: #ff6600; background: #1a0800;
-  box-shadow: 0 0 6px rgba(255,102,0,0.15);
 }
 .src-icon  { font-size: 10px; }
 .src-label { text-transform: uppercase; }
@@ -511,13 +507,11 @@ html, body {
   align-items: center;
   gap: 14px;
   padding: 8px 18px;
-  background: linear-gradient(to bottom, rgba(0, 0, 0, 0.94) 0%, rgba(0, 0, 0, 0.72) 100%);
-  -webkit-backdrop-filter: blur(10px);
-  backdrop-filter: blur(10px);
+  background: #040400;
   border-bottom: 1px solid #1e1e00;
 }
 .rp-toggle-btn, .rp-toggle-close {
-  background: rgba(8, 8, 0, 0.9);
+  background: #080800;
   color: #ccccaa;
   border: 1px solid #2a2a00;
   font: 700 10px "Courier New", monospace;
@@ -971,8 +965,8 @@ html, body {
 }
 
 .rp-cl-cnt {
-  font-size: 18px; font-weight: 700; color: var(--cl-color, #2a2a10);
-  line-height: 1; opacity: 0.6;
+  font-size: 18px; font-weight: 700; color: var(--cl-color, #445544);
+  line-height: 1;
 }
 
 .rp-cl-desc {
@@ -1157,21 +1151,20 @@ html, body {
 .cl-pill {
   display: flex; align-items: center; gap: 6px;
   padding: 4px 8px 4px 6px;
-  background: rgba(0,0,0,0.75); border: 1px solid #1e1e0088;
+  background: #050500; border: 1px solid #1e1e00;
   cursor: pointer; font-family: 'IBM Plex Mono', monospace;
   font-size: 8px; font-weight: 700; letter-spacing: 0.08em;
   color: #667755; transition: color 0.1s, border-color 0.1s, background 0.1s;
-  backdrop-filter: blur(4px);
 }
-.cl-pill:hover { color: #ccccaa; border-color: #334433; background: rgba(0,0,0,0.9); }
+.cl-pill:hover { color: #ccccaa; border-color: #334433; background: #0a0a00; }
 .cl-pill.cl-pill-active {
-  color: #ffffff; border-color: var(--cl-col); background: rgba(0,0,0,0.92);
+  color: #e8e0c8; border-color: var(--cl-col); background: #0a0a00;
 }
 .cl-pill-dot {
   width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0;
-  background: var(--cl-col); opacity: 0.8;
+  background: var(--cl-col);
 }
-.cl-pill.cl-pill-active .cl-pill-dot { opacity: 1; box-shadow: 0 0 4px var(--cl-col); }
+.cl-pill.cl-pill-active .cl-pill-dot { border: 1px solid var(--cl-col); }
 .cl-pill-lbl { flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 120px; }
 .cl-pill-key {
   font-size: 7px; color: #334433; border: 1px solid #1e1e00;
@@ -1185,22 +1178,20 @@ html, body {
 }
 .overlay-btn {
   font-family: 'IBM Plex Mono', monospace; font-size: 8px; font-weight: 700;
-  letter-spacing: 0.1em; color: #334433; background: rgba(0,0,0,0.75);
+  letter-spacing: 0.1em; color: #334433; background: #050500;
   border: 1px solid #1e1e00; padding: 4px 8px; cursor: pointer;
-  backdrop-filter: blur(4px);
   transition: color 0.1s, border-color 0.1s, background 0.1s;
 }
 .overlay-btn:hover  { color: #ccccaa; border-color: #334433; }
-.overlay-btn.overlay-active { color: #ff6600; border-color: #ff6600; background: rgba(17,9,0,0.9); }
+.overlay-btn.overlay-active { color: #ff6600; border-color: #ff6600; background: #110900; }
 
 /* ── Canvas: key stats persistent strip (C-12) ───────────────────────────── */
 .stats-strip {
   position: absolute; bottom: 0; left: 0; right: 0; z-index: 10;
   display: flex; align-items: center; gap: 0;
   padding: 0 12px; height: 24px;
-  background: rgba(0,0,0,0.82); border-top: 1px solid #1e1e00;
+  background: #040400; border-top: 1px solid #1e1e00;
   overflow: hidden; pointer-events: none;
-  backdrop-filter: blur(4px);
 }
 .stats-strip.hidden { display: none; }
 .ss-title {
@@ -1369,8 +1360,8 @@ html, body {
   align-items: center;
   padding: 8px 18px 10px;
   gap: 12px;
-  background: linear-gradient(to top, rgba(0, 0, 0, 0.85) 0%, rgba(0, 0, 0, 0.25) 85%, rgba(0, 0, 0, 0) 100%);
-  border-top: 1px solid rgba(30, 30, 0, 0.6);
+  background: #040400;
+  border-top: 1px solid #1e1e00;
 }
 .sl-topbar-left {
   display: flex; align-items: baseline; gap: 14px;
@@ -1391,7 +1382,7 @@ html, body {
   display: flex; gap: 6px; flex: 0 0 auto;
 }
 .sl-nav-btn, .sl-mode-btn, .sl-close {
-  background: rgba(8, 8, 0, 0.8);
+  background: #080800;
   color: #ccccaa;
   border: 1px solid #2a2a00;
   font: 700 10px "Courier New", monospace;
@@ -1409,15 +1400,13 @@ html, body {
   flex: 0 0 auto;
   height: 2px;
   margin: 0 18px 6px;
-  background: rgba(40, 24, 0, 0.75);
-  border-radius: 1px;
+  background: #281800;
   overflow: hidden;
 }
 .sl-progress-fill {
   height: 100%;
   width: 0%;
-  background: linear-gradient(to right, #ff6600, #ffaa00);
-  box-shadow: 0 0 6px rgba(255, 136, 0, 0.5);
+  background: #ff6600;
   transition: width 0.28s cubic-bezier(0.2, 0.7, 0.2, 1);
 }
 
@@ -1440,33 +1429,26 @@ html, body {
 .sl-slide {
   flex: 0 0 min(720px, 88vw);
   scroll-snap-align: center;
-  background: rgba(6, 6, 0, 0.92);
-  -webkit-backdrop-filter: blur(14px) saturate(1.1);
-  backdrop-filter: blur(14px) saturate(1.1);
+  background: #060600;
   border: 1px solid #1e1e00;
   border-left: 5px solid #3a2200;
-  border-radius: 2px 4px 4px 2px;
   padding: 16px 22px 20px;
   display: flex;
   flex-direction: column;
   color: #e8e0c8;
   overflow-y: auto;
-  box-shadow: 0 -4px 28px rgba(0, 0, 0, 0.7);
   opacity: 0.55;
   transform: scale(0.97);
   transform-origin: center bottom;
   transition: opacity 0.22s ease,
               transform 0.22s cubic-bezier(0.2, 0.7, 0.2, 1),
-              border-left-color 0.22s ease,
-              box-shadow 0.22s ease;
+              border-left-color 0.22s ease;
   scrollbar-width: thin;
   scrollbar-color: #2a1a00 transparent;
 }
 .sl-slide.sl-active {
   border-left-color: #ff6600;
-  box-shadow:
-    0 -6px 36px rgba(255, 102, 0, 0.32),
-    inset 3px 0 0 rgba(255, 170, 0, 0.15);
+  border-left-width: 5px;
   opacity: 1;
   transform: scale(1);
 }
@@ -1532,9 +1514,9 @@ html, body {
   padding: 4px 12px;
   margin: 4px 0 6px;
   cursor: pointer;
-  background: rgba(26, 14, 0, 0.5);
+  background: #1a0e00;
 }
-.sl-ebadge:hover { background: rgba(42, 22, 0, 0.7); }
+.sl-ebadge:hover { background: #2a1600; }
 .sl-ebadge-type  { font-size: 9px; font-weight: 700; letter-spacing: 0.12em; }
 .sl-ebadge-lbl   { font-size: 16px; color: #e8e0c8; font-weight: 600; }
 
@@ -1576,7 +1558,7 @@ html, body {
   color: #886644; letter-spacing: 0.08em;
   border: 1px solid #2a1a00;
   padding: 2px 7px; text-transform: uppercase;
-  background: rgba(20, 12, 0, 0.4);
+  background: #140c00;
 }
 .sl-title-spine {
   display: flex; flex-wrap: wrap; gap: 4px;
@@ -1623,7 +1605,7 @@ html, body {
   font-size: 10px; color: #cc88ff;
   border: 1px solid #331144;
   padding: 2px 7px;
-  background: rgba(20, 8, 32, 0.4);
+  background: #140820;
 }
 
 /* Beat */
@@ -1660,7 +1642,7 @@ html, body {
   margin: 8px 0;
   border: 1px solid #1e1e00;
   padding: 4px;
-  background: rgba(20, 12, 0, 0.3);
+  background: #140c00;
 }
 .sl-diagram-img { width: 100%; height: auto; display: block; }
 
@@ -1771,12 +1753,12 @@ html, body {
   width: 28px; height: 28px;
   display: flex; align-items: center; justify-content: center;
   border: 1px solid currentColor;
-  background: rgba(10, 6, 0, 0.6);
+  background: #0a0600;
   cursor: pointer;
   font: 700 10px "Courier New", monospace;
   transition: background 0.12s, transform 0.12s;
 }
-.sl-arc-block:hover { background: rgba(40, 20, 0, 0.8); transform: scale(1.08); }
+.sl-arc-block:hover { background: #281400; transform: scale(1.08); }
 .sl-arc-low    { color: #556644; }
 .sl-arc-medium { color: #cc8800; }
 .sl-arc-high   { color: #ff4400; }
@@ -1796,7 +1778,7 @@ html, body {
   margin-top: 8px;
 }
 .sl-action-btn {
-  background: rgba(10, 6, 0, 0.8);
+  background: #0a0600;
   color: #ccccaa;
   border: 1px solid #2a1a00;
   font: 700 10px "Courier New", monospace;
@@ -1814,7 +1796,8 @@ html, body {
   display: flex; justify-content: center; align-items: center;
   gap: 3px;
   padding: 4px 12px 8px;
-  background: linear-gradient(to top, rgba(0, 0, 0, 0.9), rgba(0, 0, 0, 0.4));
+  background: #040400;
+  border-top: 1px solid #1e1e00;
   overflow-x: auto;
   scrollbar-width: none;
 }
@@ -2003,12 +1986,10 @@ html, body {
     max-height: 70dvh;
     overflow-y: auto;
     z-index: 80;
-    border-top: 1px solid #2a2a00;
+    border-top: 2px solid #2a2a00;
     border-right: none;
-    border-radius: 6px 6px 0 0;
     transform: translateY(100%);
     transition: transform 0.24s cubic-bezier(0.4, 0, 0.2, 1);
-    box-shadow: 0 -8px 32px rgba(0, 0, 0, 0.7);
   }
   .detail-panel.open {
     transform: translateY(0);
@@ -2044,7 +2025,7 @@ html, body {
     left: 0; right: 0;
     overflow-x: auto; scrollbar-width: none;
     padding: 4px 8px;
-    background: rgba(0,0,0,0.75);
+    background: #050500;
     border-top: 1px solid #1e1e00;
   }
   .cluster-pills::-webkit-scrollbar { display: none; }
@@ -2110,7 +2091,7 @@ html, body {
 .detail-backdrop {
   display: none;
   position: fixed; inset: 0;
-  background: rgba(0, 0, 0, 0.55);
+  background: #0000008c;
   z-index: 75;
   opacity: 0;
   transition: opacity 0.2s ease;
@@ -2186,7 +2167,7 @@ html, body {
 }
 
 .mobile-nav-btn {
-  background: rgba(4, 4, 0, 0.82);
+  background: #040400;
   border: 1px solid #2a2a00;
   color: #667755;
   font-family: 'IBM Plex Mono', 'Courier New', monospace;
@@ -2195,7 +2176,6 @@ html, body {
   width: 48px;
   height: 48px;
   cursor: pointer;
-  border-radius: 3px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -2206,7 +2186,7 @@ html, body {
 .mobile-nav-btn:active {
   color: #ff6600;
   border-color: #ff6600;
-  background: rgba(20, 8, 0, 0.92);
+  background: #140800;
 }
 
 @media (max-width: 768px) {
@@ -2265,7 +2245,6 @@ html, body {
 .explore-bar {
   display: flex; align-items: center; gap: 0;
   background: #080800; border: 1px solid #ff6600;
-  box-shadow: 0 0 24px rgba(255,102,0,0.18);
   pointer-events: all; width: 100%;
 }
 
@@ -2297,7 +2276,6 @@ html, body {
   display: flex; align-items: center; gap: 8px; flex-wrap: wrap;
   background: #050500; border: 1px solid #ff4400;
   padding: 6px 10px; pointer-events: all; width: 100%;
-  box-shadow: 0 0 16px rgba(255,68,0,0.15);
   transition: opacity 0.15s;
 }
 .explore-delta-bar.hidden { display: none; }
@@ -2319,8 +2297,8 @@ html, body {
 }
 .explore-action-btn.hidden { display: none; }
 
-.expand-btn  { background: #001a0a; border-color: #00ff66; color: #00ff66; }
-.expand-btn:hover  { background: #00ff66; color: #000; }
+.expand-btn  { background: #001a0a; border-color: #00ff88; color: #00ff88; }
+.expand-btn:hover  { background: #00ff88; color: #000; }
 
 .rethink-btn { background: #1a0800; border-color: #ff6600; color: #ff6600; }
 .rethink-btn:hover { background: #ff6600; color: #000; }
@@ -2338,7 +2316,7 @@ html, body {
   width: min(400px, calc(100vw - 24px));
   background: #080800;
   border: 1px solid #1e1e00;
-  box-shadow: -4px 0 24px rgba(0,0,0,0.8);
+  border-right: 2px solid #445544;
   transform: translateX(100%);
   transition: transform 0.18s ease;
   z-index: 110;
@@ -2461,8 +2439,8 @@ html, body {
   animation: zs-pulse 2.6s ease-in-out infinite;
 }
 @keyframes zs-pulse {
-  0%, 100% { opacity: 1; text-shadow: 0 0 0 rgba(255,102,0,0); }
-  50%       { opacity: 0.65; text-shadow: 0 0 22px rgba(255,102,0,0.45); }
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.55; }
 }
 .zs-wordmark {
   font-size: 30px; font-weight: 700; color: #e8e0c8;
@@ -2470,14 +2448,13 @@ html, body {
 }
 
 .zs-tagline {
-  font-size: 10px; color: #334433; letter-spacing: 0.22em;
+  font-size: 10px; color: #445544; letter-spacing: 0.22em;
   text-transform: uppercase; margin-top: -14px;
 }
 
 .zs-input-wrap {
   display: flex; align-items: stretch; width: 100%;
   border: 1px solid #ff6600;
-  box-shadow: 0 0 28px rgba(255,102,0,0.1);
 }
 .zs-prompt {
   font-size: 11px; font-weight: 700; color: #ff6600;
@@ -2494,7 +2471,7 @@ html, body {
   padding: 13px 14px;
   letter-spacing: 0.02em;
 }
-.zs-input::placeholder { color: #1e1e00; }
+.zs-input::placeholder { color: #2a2a10; }
 .zs-submit {
   background: #ff6600; border: none; color: #000;
   font-family: 'IBM Plex Mono', monospace;
@@ -2518,15 +2495,55 @@ html, body {
 .zs-seed:hover { color: #ff6600; border-color: #ff6600; background: #100800; }
 
 .zs-hint {
-  font-size: 9px; color: #1a1a00; letter-spacing: 0.12em;
+  font-size: 9px; color: #334422; letter-spacing: 0.12em;
 }
-.zs-hint em { font-style: normal; color: #445533; }
+.zs-hint em { font-style: normal; color: #667744; }
+
+/* ── Zero state: boot ritual ──────────────────────────────────────────────── */
+
+.zs-boot {
+  position: relative; z-index: 1;
+  font-family: 'IBM Plex Mono', 'Courier New', monospace;
+  font-size: 11px; color: #445544; letter-spacing: 0.06em;
+  line-height: 2;
+  transition: opacity 0.3s ease;
+}
+.zs-boot.zs-boot-out {
+  opacity: 0; pointer-events: none;
+}
+
+.zs-boot-line {
+  opacity: 0;
+  animation: zs-bl-in 0.08s ease forwards;
+}
+@keyframes zs-bl-in { to { opacity: 1; } }
+
+.zs-bl-0 { animation-delay: 0ms;    color: #667755; font-weight: 700; letter-spacing: 0.1em; }
+.zs-bl-1 { animation-delay: 200ms;  color: #2a2a10; }
+.zs-bl-2 { animation-delay: 500ms;  }
+.zs-bl-3 { animation-delay: 800ms;  }
+.zs-bl-4 { animation-delay: 1100ms; }
+.zs-bl-5 { animation-delay: 1350ms; color: #2a2a10; }
+.zs-bl-6 { animation-delay: 1600ms; color: #ccccaa; font-weight: 700; letter-spacing: 0.12em; }
+
+.zs-bl-ok     { color: #00ff88; }
+.zs-bl-cursor { color: #ff6600; animation: zs-bl-blink 1s step-end infinite; }
+@keyframes zs-bl-blink { 0%, 100% { opacity: 1; } 50% { opacity: 0; } }
+
+/* Body starts hidden during boot, fades in after */
+.zs-body-hidden {
+  opacity: 0; pointer-events: none;
+  transition: opacity 0.35s ease;
+}
+.zs-body-hidden.zs-body-visible {
+  opacity: 1; pointer-events: auto;
+}
 
 /* ── Canvas loader ────────────────────────────────────────────────────────── */
 .canvas-loader {
   position: absolute; inset: 0; z-index: 9;
   display: flex; align-items: center; justify-content: center;
-  background: rgba(0,0,0,0.82);
+  background: #000000;
   pointer-events: none;
   transition: opacity 0.35s ease;
 }
@@ -2564,7 +2581,7 @@ html, body {
   width: 220px; height: 1px; background: #1e1e00;
 }
 .cl-progress-fill {
-  height: 100%; background: linear-gradient(to right, #ff6600, #ffaa00);
+  height: 100%; background: #ff6600;
   width: 0%;
   transition: width 0.6s ease;
 }
@@ -2619,7 +2636,7 @@ html, body {
 .sl-paint-btn:hover:not(:disabled) {
   color: #ff6600;
   border-color: #ff6600;
-  background: rgba(255, 102, 0, 0.06);
+  background: #110500;
 }
 .sl-paint-btn:disabled {
   color: #332211;


### PR DESCRIPTION
Cognitive Test Driven Development spec (CTDD.md) defines 9 tests; all previously-failing tests now pass.

CT-01 to CT-07 — anti-pattern purge (style.css):
- Remove all box-shadow and backdrop-filter (terminal grammar violation)
- Flatten all linear-gradient and rgba() state colors to explicit hex tokens
- Fix invisible text: fnkey bar, breadcrumb empty/sep, dp-section-hdr, dp-footer
- Fix zero state: tagline contrast, zs-hint, placeholder, drop text-shadow from pulse
- Unify green accent #00ff66 → #00ff88 (canonical geographic token)
- Drawers gain accent borders instead of shadows
- Slide view: remove backdrop-filter, flatten progress/dots/topbar backgrounds

CT-08 — color connectivity:
- ontology.mjs: add colorToCSS(hex) to convert Three.js 0xRRGGBB to '#rrggbb'
- breadcrumb.mjs: pushCrumb(qid, label, type) stores entity type; _render() inlines border-left-color per crumb from entity color
- detail.mjs: dp-header gets border-left accent, dp-type-label gets entity color
- main.mjs + garden-main.mjs: all pushCrumb call sites thread node.type

CT-09 — boot ritual:
- index.html: #zs-boot block (7 lines) shown before explore UI
- style.css: staggered animation-delay 0–1600ms; zs-body-hidden → visible crossfade
- main.mjs: 2300ms timeout (last line 1600ms + 700ms hold) then fade to explore